### PR TITLE
CLI Test with Custom `System.in` input

### DIFF
--- a/app/src/main/java/seng/monsters/model/Inventory.java
+++ b/app/src/main/java/seng/monsters/model/Inventory.java
@@ -71,7 +71,7 @@ public final class Inventory {
      * @return An int representing the number of the item in the player's inventory
      */
     public int getItemNumber(Item item) {
-        return items.get(item);
+        return items.getOrDefault(item, 0);
     }
 
     /**

--- a/app/src/main/java/seng/monsters/ui/cli/BattleCLI.java
+++ b/app/src/main/java/seng/monsters/ui/cli/BattleCLI.java
@@ -17,7 +17,7 @@ import java.util.Set;
 /**
  * TODO: This is still a testing CLI, it works but need checks and testing to use it in the final application
  */
-public final class BattleCLI implements BattleManager.UI {
+public final class BattleCLI extends TestableCLI implements BattleManager.UI {
     private final BattleManager battler;
     private final Set<String> loggedFeeds = new HashSet<>();
 

--- a/app/src/main/java/seng/monsters/ui/cli/InventoryCLI.java
+++ b/app/src/main/java/seng/monsters/ui/cli/InventoryCLI.java
@@ -9,11 +9,10 @@ import java.util.InputMismatchException;
 import java.util.List;
 import java.util.Scanner;
 
-public final class InventoryCLI {
+public final class InventoryCLI extends TestableCLI {
     private final GameManager gameManager;
     private final Inventory inventory;
     private final List<Monster> party;
-    private final Scanner input = new Scanner(System.in);
 
     public InventoryCLI(GameManager gameManager) {
         this.gameManager = gameManager;
@@ -30,10 +29,10 @@ public final class InventoryCLI {
         displayInventoryOptions();
         while (true) {
             try {
-                selectItem(input.nextInt());
+                selectItem(input().nextInt());
                 return;
             } catch (InputMismatchException e) {
-                input.next();
+                input().next();
                 System.out.println("Invalid input!");
             }
         }
@@ -48,10 +47,10 @@ public final class InventoryCLI {
         displayUseItemOptions(item, itemUsed);
         while (true) {
             try {
-                useItemOnMonster(item, input.nextInt());
+                useItemOnMonster(item, input().nextInt());
                 return;
             } catch (InputMismatchException e) {
-                input.next();
+                input().next();
                 System.out.println("Invalid input!");
             }
         }
@@ -74,7 +73,7 @@ public final class InventoryCLI {
             }
         } catch (IllegalArgumentException e) {
             System.out.println("Invalid input!");
-            selectItem(input.nextInt());
+            selectItem(input().nextInt());
         }
     }
 
@@ -95,13 +94,13 @@ public final class InventoryCLI {
             }
         } catch (IllegalArgumentException e) {
             System.out.println("Invalid input!");
-            useItemOnMonster(item, input.nextInt());
+            useItemOnMonster(item, input().nextInt());
         } catch (Item.NoEffectException e) {
             System.out.println("That item has no effect on this monster!");
-            useItemOnMonster(item, input.nextInt());
+            useItemOnMonster(item, input().nextInt());
         } catch (Inventory.ItemNotExistException e) {
             System.out.println("You don't have any of that item!");
-            useItemOnMonster(item, input.nextInt());
+            useItemOnMonster(item, input().nextInt());
         }
     }
 

--- a/app/src/main/java/seng/monsters/ui/cli/MainMenuCLI.java
+++ b/app/src/main/java/seng/monsters/ui/cli/MainMenuCLI.java
@@ -4,6 +4,7 @@ import seng.monsters.model.GameManager;
 import seng.monsters.model.Monster;
 
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.Scanner;
 
 public class MainMenuCLI extends TestableCLI {
@@ -20,16 +21,14 @@ public class MainMenuCLI extends TestableCLI {
     // TODO: Implement primary functionality of Main Menu
 
 
-    public static Monster monsterJoinsPartyInterface(Monster mon) {
+    public static Monster monsterJoinsPartyInterface(Scanner input, Monster mon) {
         monsterJoinsPartyMessage(mon);
-        monsterJoinsParty(mon);
-        return mon;
+        return monsterJoinsParty(input, mon);
     }
 
-    public static Monster monsterJoinsParty(Monster mon) throws IllegalArgumentException {
-        final var input = new Scanner(System.in);
+    public static Monster monsterJoinsParty(Scanner input, Monster mon) throws IllegalArgumentException {
         try {
-            final var name = input.nextLine();
+            final var name = input.next();
             if (((name.length() >= 3) && (name.length() <= 15) && (name.matches("[a-zA-Z]+")))) {
                 mon.setName(name);
             } else if (!name.matches("")) {
@@ -37,7 +36,7 @@ public class MainMenuCLI extends TestableCLI {
             }
         } catch (IllegalArgumentException ignored) {
             System.out.println("Invalid name! (Must be between 3 and 15 letters inclusive, no symbols or numbers)");
-            return monsterJoinsParty(mon);
+            return monsterJoinsParty(input, mon);
         }
         return mon;
     }

--- a/app/src/main/java/seng/monsters/ui/cli/MainMenuCLI.java
+++ b/app/src/main/java/seng/monsters/ui/cli/MainMenuCLI.java
@@ -6,11 +6,10 @@ import seng.monsters.model.Monster;
 import java.util.List;
 import java.util.Scanner;
 
-public class MainMenuCLI {
+public class MainMenuCLI extends TestableCLI {
 
     private final GameManager gameManager;
     private final List<String> menuOptions = List.of("Manage Party", "Battle", "View Item Inventory", "Enter Shop", "Sleep");
-    private final Scanner input = new Scanner(System.in);
 
     public MainMenuCLI(GameManager gameManager) {
         this.gameManager = gameManager;

--- a/app/src/main/java/seng/monsters/ui/cli/PartyCLI.java
+++ b/app/src/main/java/seng/monsters/ui/cli/PartyCLI.java
@@ -5,15 +5,13 @@ import seng.monsters.model.Monster;
 
 import java.util.InputMismatchException;
 import java.util.List;
-import java.util.Scanner;
 
-public final class PartyCLI {
+public final class PartyCLI extends TestableCLI {
     private final GameManager gameManager;
     private final List<Monster> party;
 
-    private final Scanner input = new Scanner(System.in);
-
     public PartyCLI(GameManager gameManager) {
+        super();
         this.gameManager = gameManager;
         this.party = gameManager.getTrainer().getParty();
     }
@@ -28,10 +26,10 @@ public final class PartyCLI {
         displayPartyStats(monsterMoved);
         while (true) {
             try {
-                selectMonsterToMove(input.nextInt());
+                selectMonsterToMove(input().nextInt());
                 return;
             } catch (InputMismatchException e) {
-                input.next();
+                input().next();
                 System.out.println("Invalid input!");
             }
         }
@@ -47,9 +45,9 @@ public final class PartyCLI {
         displayMoveMonsters(mon);
         while (true) {
             try {
-                return selectMonsterToSwap(mon, input.nextInt());
+                return selectMonsterToSwap(mon, input().nextInt());
             } catch (InputMismatchException e) {
-                input.next();
+                input().next();
                 System.out.println("Invalid input!");
             }
         }
@@ -73,10 +71,10 @@ public final class PartyCLI {
             }
         } catch (IllegalArgumentException | InputMismatchException e) {
             System.out.println("Invalid input!");
-            selectMonsterToMove(input.nextInt());
+            selectMonsterToMove(input().nextInt());
         } catch (IndexOutOfBoundsException e) {
             System.out.println("No monster in that position!");
-            selectMonsterToMove(input.nextInt());
+            selectMonsterToMove(input().nextInt());
         }
     }
 
@@ -99,10 +97,10 @@ public final class PartyCLI {
             }
         } catch (IllegalArgumentException | InputMismatchException e) {
             System.out.println("Invalid input!");
-            return selectMonsterToSwap(mon, input.nextInt());
+            return selectMonsterToSwap(mon, input().nextInt());
         } catch (IndexOutOfBoundsException e) {
             System.out.println("No monster in that position!");
-            return selectMonsterToSwap(mon, input.nextInt());
+            return selectMonsterToSwap(mon, input().nextInt());
         }
         return false;
     }

--- a/app/src/main/java/seng/monsters/ui/cli/SetupCLI.java
+++ b/app/src/main/java/seng/monsters/ui/cli/SetupCLI.java
@@ -35,7 +35,7 @@ public class SetupCLI extends TestableCLI {
         welcomeMessage();
         while (true) {
             try {
-                return chooseName(input().nextLine());
+                return chooseName(input().next());
             } catch (InputMismatchException e) {
                 input().next();
                 System.out.println("Invalid name! (Must be between 3 and 15 letters inclusive, no symbols or numbers)");
@@ -90,7 +90,7 @@ public class SetupCLI extends TestableCLI {
             }
         } catch (IllegalArgumentException e) {
             System.out.println("Invalid name! (Must be between 3 and 15 letters inclusive, no symbols or numbers)");
-            return chooseName(input().nextLine());
+            return chooseName(input().next());
         }
     }
 
@@ -126,7 +126,7 @@ public class SetupCLI extends TestableCLI {
     public Monster selectStartingMonster(int scannerInput) {
         try {
             if ((scannerInput > 0) && (scannerInput < 4)) {
-                return MainMenuCLI.monsterJoinsPartyInterface(starterMonsters.get(scannerInput - 1));
+                return MainMenuCLI.monsterJoinsPartyInterface(input(), starterMonsters.get(scannerInput - 1));
             } else {
                 throw new IllegalArgumentException();
             }

--- a/app/src/main/java/seng/monsters/ui/cli/SetupCLI.java
+++ b/app/src/main/java/seng/monsters/ui/cli/SetupCLI.java
@@ -10,7 +10,7 @@ import java.util.Scanner;
 
 // TODO: Needs more testing
 
-public class SetupCLI {
+public class SetupCLI extends TestableCLI {
 
     private final List<Monster> starterMonsters = List.of(
         new Monster.Quacker(1),
@@ -18,7 +18,6 @@ public class SetupCLI {
         new Monster.Tree(1)
     );
     private final List<String> difficulties = List.of("Normal", "Hard", "Utterly Impossible");
-    private final Scanner input = new Scanner(System.in);
 
 
     public void setup() {
@@ -36,9 +35,9 @@ public class SetupCLI {
         welcomeMessage();
         while (true) {
             try {
-                return chooseName(input.nextLine());
+                return chooseName(input().nextLine());
             } catch (InputMismatchException e) {
-                input.next();
+                input().next();
                 System.out.println("Invalid name! (Must be between 3 and 15 letters inclusive, no symbols or numbers)");
             }
         }
@@ -48,9 +47,9 @@ public class SetupCLI {
         dayNumberMessage();
         while (true) {
             try {
-                return chooseMaxDays(input.nextInt());
+                return chooseMaxDays(input().nextInt());
             } catch (InputMismatchException e) {
-                input.next();
+                input().next();
                 System.out.println("Invalid input! (Must be a number between 5 and 15 inclusive)");
             }
         }
@@ -60,9 +59,9 @@ public class SetupCLI {
         displayDifficulties();
         while (true) {
             try {
-                return selectDifficulty(input.nextInt());
+                return selectDifficulty(input().nextInt());
             } catch (InputMismatchException e) {
-                input.next();
+                input().next();
                 System.out.println("Invalid input!");
             }
         }
@@ -72,9 +71,9 @@ public class SetupCLI {
         displayStartingMonsters();
         while (true) {
             try {
-                return selectStartingMonster(input.nextInt());
+                return selectStartingMonster(input().nextInt());
             } catch (InputMismatchException e) {
-                input.next();
+                input().next();
                 System.out.println("Invalid input!");
             }
         }
@@ -91,7 +90,7 @@ public class SetupCLI {
             }
         } catch (IllegalArgumentException e) {
             System.out.println("Invalid name! (Must be between 3 and 15 letters inclusive, no symbols or numbers)");
-            return chooseName(input.nextLine());
+            return chooseName(input().nextLine());
         }
     }
 
@@ -105,7 +104,7 @@ public class SetupCLI {
             }
         } catch (IllegalArgumentException e) {
             System.out.println("Invalid input! (Must be a number between 5 and 15 inclusive)");
-            return chooseMaxDays(input.nextInt());
+            return chooseMaxDays(input().nextInt());
         }
     }
 
@@ -119,7 +118,7 @@ public class SetupCLI {
             }
         } catch (IllegalArgumentException e) {
             System.out.println("Invalid input!");
-            return selectDifficulty(input.nextInt());
+            return selectDifficulty(input().nextInt());
         }
     }
 
@@ -133,7 +132,7 @@ public class SetupCLI {
             }
         } catch (IllegalArgumentException e) {
             System.out.println("Invalid input!");
-            return selectStartingMonster(input.nextInt());
+            return selectStartingMonster(input().nextInt());
         }
     }
 

--- a/app/src/main/java/seng/monsters/ui/cli/TestableCLI.java
+++ b/app/src/main/java/seng/monsters/ui/cli/TestableCLI.java
@@ -1,0 +1,36 @@
+//
+//  TestableCLI.java
+//  seng-monsters
+//
+//  Created by d-exclaimation on 13:55.
+//  Copyright © 2022 d-exclaimation. All rights reserved.
+//
+package seng.monsters.ui.cli;
+
+import java.util.Scanner;
+
+/**
+ * Base for a Testable CLI that takes input from the <code>System.in</code>
+ */
+public abstract class TestableCLI {
+    /**
+     * The current input
+     */
+    private Scanner inputScanner = new Scanner(System.in);
+
+    /**
+     * Get the input as of now
+     *
+     * @return The input as Scanner
+     */
+    public final Scanner input() {
+        return inputScanner;
+    }
+
+    /**
+     * Refresh the input scanner to have the updated <code>System.in</code>
+     */
+    protected final void refreshSystemIn() {
+        inputScanner = new Scanner(System.in);
+    }
+}

--- a/app/src/main/java/seng/monsters/ui/cli/TestableCLI.java
+++ b/app/src/main/java/seng/monsters/ui/cli/TestableCLI.java
@@ -8,6 +8,7 @@
 package seng.monsters.ui.cli;
 
 import java.util.Scanner;
+import java.util.regex.Pattern;
 
 /**
  * Base for a Testable CLI that takes input from the <code>System.in</code>
@@ -16,7 +17,7 @@ public abstract class TestableCLI {
     /**
      * The current input
      */
-    private Scanner inputScanner = new Scanner(System.in);
+    private Scanner inputScanner = TestableCLI.customInputScanner();
 
     /**
      * Get the input as of now
@@ -31,6 +32,12 @@ public abstract class TestableCLI {
      * Refresh the input scanner to have the updated <code>System.in</code>
      */
     protected final void refreshSystemIn() {
-        inputScanner = new Scanner(System.in);
+        inputScanner = TestableCLI.customInputScanner();
+    }
+
+    private static Scanner customInputScanner() {
+        final var inputScanner = new Scanner(System.in);
+        inputScanner.useDelimiter("\\n");
+        return inputScanner;
     }
 }

--- a/app/src/test/java/seng/monsters/ui/cli/CLITestBase.java
+++ b/app/src/test/java/seng/monsters/ui/cli/CLITestBase.java
@@ -1,0 +1,75 @@
+//
+//  CLITestBase.java
+//  seng-monsters
+//
+//  Created by d-exclaimation on 14:15.
+//  Copyright © 2022 d-exclaimation. All rights reserved.
+//
+package seng.monsters.ui.cli;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.PrintStream;
+import java.util.Collection;
+
+public abstract class CLITestBase {
+    private final InputStream systemIn = System.in;
+    private final PrintStream systemOut = System.out;
+
+    private ByteArrayOutputStream testOut;
+
+    /**
+     * The TestableCLI being tested
+     *
+     * @return The CLI itself
+     */
+    public abstract TestableCLI cli();
+
+    /**
+     * Base setup method to be called on <code>@BeforeEach</code>
+     */
+    protected void baseSetup() {
+        testOut = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(testOut));
+    }
+
+    /**
+     * Base teardown method to be called on <code>@AfterEach</code>
+     */
+    protected void baseTeardown() {
+        System.setIn(systemIn);
+        System.setOut(systemOut);
+    }
+
+    /**
+     * Provide the <code>System.in</code> with a single input that can be acquired through <code>Scanner::nextLine</code>
+     *
+     * @param data The input as string
+     */
+    protected void provideInput(String data) {
+        System.setIn(new ByteArrayInputStream(data.getBytes()));
+        cli().refreshSystemIn();
+    }
+
+    /**
+     * Provide the <code>System.in</code> with multiple inputs that can be acquired through <code>Scanner::nextLine</code>
+     *
+     * @param data The input as a collection of string
+     */
+    protected void provideMultipleInput(Collection<String> data) {
+        final var input = String.join("\n", data);
+        provideInput(input);
+    }
+
+    /**
+     * Take a snapshot of the current <code>System.out</code> and return it as String
+     *
+     * @return The output as string
+     */
+    protected String acquireOutput() {
+        final var current = testOut.toString();
+        baseSetup();
+        return current;
+    }
+}

--- a/app/src/test/java/seng/monsters/ui/cli/InventoryCLITest.java
+++ b/app/src/test/java/seng/monsters/ui/cli/InventoryCLITest.java
@@ -38,6 +38,17 @@ class InventoryCLITest extends CLITestBase {
         baseTeardown();
     }
 
+    /**
+     * InventoryCLI's `<code>inventoryInterface</code>:
+     * <ul>
+     * <li>Wait until given input</li>
+     * <li>Exit if given <code>0</code> as input</li>
+     * <li>Not use item that doesn't exist in the inventory</li>
+     * <li>Properly process all exception thrown by model classes</li>
+     * <li>Apply item from inventory to the selected monster, if given valid indices for item and monster</li>
+     * <li>Loop if given an invalid input, prompt user <code>Invalid input!</code>, and continue as normal</li>
+     * </ul>
+     */
     @Test
     void inventoryInterface() {
         // Immediately exit with 0
@@ -78,6 +89,17 @@ class InventoryCLITest extends CLITestBase {
         assertNotEquals(currHp3, labMonster.getCurrentHp());
     }
 
+    /**
+     * InventoryCLI's `<code>useItemInterface</code>:
+     * <ul>
+     * <li>Wait until given input</li>
+     * <li>Exit if given <code>0</code> as input</li>
+     * <li>Not use item that doesn't exist in the inventory</li>
+     * <li>Properly process all exception thrown by model classes</li>
+     * <li>Apply item from inventory to the selected monster, if given valid index for monster</li>
+     * <li>Loop if given an invalid input, prompt user <code>Invalid input!</code>, and continue as normal</li>
+     * </ul>
+     */
     @Test
     void useItemInterface() {
         // Immediately exit with 0

--- a/app/src/test/java/seng/monsters/ui/cli/InventoryCLITest.java
+++ b/app/src/test/java/seng/monsters/ui/cli/InventoryCLITest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import seng.monsters.model.GameManager;
+import seng.monsters.model.Inventory;
 import seng.monsters.model.Item;
 import seng.monsters.model.Monster;
 
@@ -13,16 +14,16 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class InventoryCLITest extends CLITestBase {
 
+    private Inventory inventory;
     private Monster labMonster;
-    private GameManager gameManager;
     private InventoryCLI inventoryCLI;
 
     @BeforeEach
     void setUp() {
+        final var gameManager = new GameManager(1000, 1, 5, 1, "Test");
         labMonster = new Monster.Doger("Good boi", 10);
-        gameManager = new GameManager(1000, 1, 5, 1, "Test");
         inventoryCLI = new InventoryCLI(gameManager);
-
+        inventory = gameManager.getInventory();
         gameManager.getTrainer().add(labMonster);
         baseSetup();
     }
@@ -39,14 +40,81 @@ class InventoryCLITest extends CLITestBase {
 
     @Test
     void inventoryInterface() {
+        // Immediately exit with 0
+        provideInput("0");
+        inventoryCLI.inventoryInterface();
+
+        // Invalid item index and exit with 0
+        provideMultipleInput(List.of("1", "1", "0", "0"));
+        inventoryCLI.inventoryInterface();
+        assertTrue(acquireOutput().contains("You don't have any of that item!"));
+
+        // Valid index and item, but item produce no effect, and exit with 0
+        inventory.add(new Item.Potion());
+        provideMultipleInput(List.of("1", "1", "0", "0"));
+        inventoryCLI.inventoryInterface();
+        assertTrue(acquireOutput().contains("That item has no effect on this monster!"));
+
+        // Valid index and item
+        labMonster.takeDamage(labMonster.maxHp() / 2);
+        final var currHp = labMonster.getCurrentHp();
+        provideMultipleInput(List.of("1", "1", "0", "0"));
+        inventoryCLI.inventoryInterface();
+        assertNotEquals(currHp, labMonster.getCurrentHp());
+
+        // Invalid input and exit with 0
+        final var currHp2 = labMonster.getCurrentHp();
+        provideMultipleInput(List.of("100", "0", "0"));
+        inventoryCLI.inventoryInterface();
+        assertEquals(currHp2, labMonster.getCurrentHp());
+
+        // Invalid input, normal flow, exit with 0
+        labMonster.takeDamage(10);
+        inventory.add(new Item.Potion());
+        final var currHp3 = labMonster.getCurrentHp();
+        provideMultipleInput(List.of("100", "1", "1", "0", "0"));
+        inventoryCLI.inventoryInterface();
+        assertTrue(acquireOutput().contains("Invalid input!"));
+        assertNotEquals(currHp3, labMonster.getCurrentHp());
     }
 
     @Test
     void useItemInterface() {
-        final var inventory = gameManager.getInventory();
-
         // Immediately exit with 0
         provideInput("0");
         inventoryCLI.useItemInterface(new Item.Potion(), false);
+
+        // Valid index but non-existing item, and exit with 0
+        provideMultipleInput(List.of("1", "0"));
+        inventoryCLI.useItemInterface(new Item.Potion(), false);
+        assertTrue(acquireOutput().contains("You don't have any of that item!"));
+
+        // Valid index and item, but item produce no effect, and exit with 0
+        inventory.add(new Item.Potion());
+        provideMultipleInput(List.of("1", "0"));
+        inventoryCLI.useItemInterface(new Item.Potion(), false);
+        assertTrue(acquireOutput().contains("That item has no effect on this monster!"));
+
+        // Valid index and item
+        labMonster.takeDamage(labMonster.maxHp() / 2);
+        final var currHp = labMonster.getCurrentHp();
+        provideMultipleInput(List.of("1", "0"));
+        inventoryCLI.useItemInterface(new Item.Potion(), false);
+        assertNotEquals(currHp, labMonster.getCurrentHp());
+
+        // Invalid input and exit with 0
+        final var currHp2 = labMonster.getCurrentHp();
+        provideMultipleInput(List.of("100", "0"));
+        inventoryCLI.useItemInterface(new Item.Potion(), false);
+        assertEquals(currHp2, labMonster.getCurrentHp());
+
+        // Invalid input, normal flow, exit with 0
+        labMonster.takeDamage(10);
+        inventory.add(new Item.Potion());
+        final var currHp3 = labMonster.getCurrentHp();
+        provideMultipleInput(List.of("100", "1", "0"));
+        inventoryCLI.useItemInterface(new Item.Potion(), false);
+        assertTrue(acquireOutput().contains("Invalid input!"));
+        assertNotEquals(currHp3, labMonster.getCurrentHp());
     }
 }

--- a/app/src/test/java/seng/monsters/ui/cli/InventoryCLITest.java
+++ b/app/src/test/java/seng/monsters/ui/cli/InventoryCLITest.java
@@ -1,0 +1,52 @@
+package seng.monsters.ui.cli;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import seng.monsters.model.GameManager;
+import seng.monsters.model.Item;
+import seng.monsters.model.Monster;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class InventoryCLITest extends CLITestBase {
+
+    private Monster labMonster;
+    private GameManager gameManager;
+    private InventoryCLI inventoryCLI;
+
+    @BeforeEach
+    void setUp() {
+        labMonster = new Monster.Doger("Good boi", 10);
+        gameManager = new GameManager(1000, 1, 5, 1, "Test");
+        inventoryCLI = new InventoryCLI(gameManager);
+
+        gameManager.getTrainer().add(labMonster);
+        baseSetup();
+    }
+
+    @Override
+    public TestableCLI cli() {
+        return inventoryCLI;
+    }
+
+    @AfterEach
+    void tearDown() {
+        baseTeardown();
+    }
+
+    @Test
+    void inventoryInterface() {
+    }
+
+    @Test
+    void useItemInterface() {
+        final var inventory = gameManager.getInventory();
+
+        // Immediately exit with 0
+        provideInput("0");
+        inventoryCLI.useItemInterface(new Item.Potion(), false);
+    }
+}

--- a/app/src/test/java/seng/monsters/ui/cli/PartyCLITest.java
+++ b/app/src/test/java/seng/monsters/ui/cli/PartyCLITest.java
@@ -1,0 +1,217 @@
+package seng.monsters.ui.cli;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import seng.monsters.model.GameManager;
+import seng.monsters.model.Monster;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PartyCLITest extends CLITestBase {
+
+    private GameManager gameManager;
+    private PartyCLI partyCLI;
+
+    @BeforeEach
+    void setUp() {
+        gameManager = new GameManager(1000, 1, 5, 1, "Test");
+        partyCLI = new PartyCLI(gameManager);
+        baseSetup();
+    }
+
+    @Override
+    public TestableCLI cli() {
+        return partyCLI;
+    }
+
+    @AfterEach
+    void tearDown() {
+        baseTeardown();
+    }
+
+    @Test
+    void partyStatsInterface() {
+        final var trainer = gameManager.getTrainer();
+        final var monsters = List.of(new Monster.Quacker("1", 1), new Monster.Eel("2", 1));
+        monsters.forEach(trainer::add);
+
+        // Immediately exit with 0
+        provideInput("0");
+        partyCLI.partyStatsInterface(false);
+
+        // Move 1 with 2, and then exit with 0
+        provideMultipleInput(List.of("1", "2", "0"));
+        partyCLI.partyStatsInterface(false);
+        assertNotEquals(monsters.get(0), trainer.getParty().get(0));
+        assertEquals(monsters.get(1), trainer.getParty().get(0));
+        assertEquals("1", trainer.getParty().get(1).getName());
+        assertEquals("2", trainer.getParty().get(0).getName());
+
+        // Move 1, but immediately exit with 0
+        provideMultipleInput(List.of("1", "0", "0"));
+        partyCLI.partyStatsInterface(false);
+        assertNotEquals(monsters.get(0), trainer.getParty().get(0));
+        assertEquals(monsters.get(1), trainer.getParty().get(0));
+        assertEquals("1", trainer.getParty().get(1).getName());
+        assertEquals("2", trainer.getParty().get(0).getName());
+
+        // Give invalid initial input and exit with 0
+        provideMultipleInput(List.of("100", "0"));
+        partyCLI.partyStatsInterface(false);
+        assertTrue(acquireOutput().contains("Invalid input!"));
+
+        // Give invalid initial input, move 1 to 2, and exit with 0
+        provideMultipleInput(List.of("100", "1", "2", "0"));
+        partyCLI.partyStatsInterface(false);
+        assertTrue(acquireOutput().contains("Invalid input!"));
+        assertEquals(monsters.get(0), trainer.getParty().get(0));
+        assertNotEquals(monsters.get(1), trainer.getParty().get(0));
+        assertEquals("1", trainer.getParty().get(0).getName());
+        assertEquals("2", trainer.getParty().get(1).getName());
+    }
+
+    @Test
+    void moveMonsterInterface() {
+        final var trainer = gameManager.getTrainer();
+        final var monsters = List.of(new Monster.Quacker("1", 1), new Monster.Eel("2", 1));
+        monsters.forEach(trainer::add);
+
+        // Immediately exit with 0
+        provideInput("0");
+        assertFalse(partyCLI.moveMonsterInterface(monsters.get(0)));
+
+        // Move existing monster with 2
+        provideInput("2");
+        assertTrue(partyCLI.moveMonsterInterface(monsters.get(0)));
+        assertNotEquals(monsters.get(0), trainer.getParty().get(0));
+        assertEquals(monsters.get(1), trainer.getParty().get(0));
+        assertEquals("1", trainer.getParty().get(1).getName());
+        assertEquals("2", trainer.getParty().get(0).getName());
+
+        // Move with invalid input, and then exit with 0
+        provideMultipleInput(List.of("100", "0"));
+        assertFalse(partyCLI.moveMonsterInterface(monsters.get(0)));
+        assertTrue(acquireOutput().contains("Invalid input!"));
+
+        // Move with invalid input, and then properly swap with 1
+        provideMultipleInput(List.of("100", "1"));
+        assertTrue(partyCLI.selectMonsterToSwap(monsters.get(0), 100));
+        assertTrue(acquireOutput().contains("Invalid input!"));
+        assertEquals(monsters.get(0), trainer.getParty().get(0));
+        assertNotEquals(monsters.get(1), trainer.getParty().get(0));
+        assertEquals("1", trainer.getParty().get(0).getName());
+        assertEquals("2", trainer.getParty().get(1).getName());
+    }
+
+    @Test
+    void selectMonsterToMove() {
+        final var trainer = gameManager.getTrainer();
+        final var monsters = List.of(new Monster.Quacker("1", 1), new Monster.Eel("2", 1));
+        monsters.forEach(trainer::add);
+
+        partyCLI.selectMonsterToMove(0);
+
+        // Move 1 with 2, and then exit with 0
+        provideMultipleInput(List.of("2", "0"));
+        partyCLI.selectMonsterToMove(1);
+        assertNotEquals(monsters.get(0), trainer.getParty().get(0));
+        assertEquals(monsters.get(1), trainer.getParty().get(0));
+        assertEquals("1", trainer.getParty().get(1).getName());
+        assertEquals("2", trainer.getParty().get(0).getName());
+
+        // Move 1, but immediately exit with 0
+        provideMultipleInput(List.of("0", "0"));
+        partyCLI.selectMonsterToMove(1);
+        assertNotEquals(monsters.get(0), trainer.getParty().get(0));
+        assertEquals(monsters.get(1), trainer.getParty().get(0));
+        assertEquals("1", trainer.getParty().get(1).getName());
+        assertEquals("2", trainer.getParty().get(0).getName());
+
+        // Give invalid initial input and exit with 0
+        provideInput("0");
+        partyCLI.selectMonsterToMove(100);
+        assertTrue(acquireOutput().contains("Invalid input!"));
+
+        // Give invalid initial input, move 1 to 2, and exit with 0
+        provideMultipleInput(List.of("1", "2", "0"));
+        partyCLI.selectMonsterToMove(100);
+        assertTrue(acquireOutput().contains("Invalid input!"));
+        assertEquals(monsters.get(0), trainer.getParty().get(0));
+        assertNotEquals(monsters.get(1), trainer.getParty().get(0));
+        assertEquals("1", trainer.getParty().get(0).getName());
+        assertEquals("2", trainer.getParty().get(1).getName());
+    }
+
+    @Test
+    void selectMonsterToSwap() {
+        final var trainer = gameManager.getTrainer();
+        final var monsters = List.of(new Monster.Quacker("1", 1), new Monster.Eel("2", 1));
+        monsters.forEach(trainer::add);
+
+        assertFalse(partyCLI.selectMonsterToSwap(new Monster.Tree(1), 0));
+
+        // Move existing monster with 2
+        assertTrue(partyCLI.selectMonsterToSwap(monsters.get(0), 2));
+        assertNotEquals(monsters.get(0), trainer.getParty().get(0));
+        assertEquals(monsters.get(1), trainer.getParty().get(0));
+        assertEquals("1", trainer.getParty().get(1).getName());
+        assertEquals("2", trainer.getParty().get(0).getName());
+
+        // Move with invalid input, and then exit with 0
+        provideInput("0");
+        assertFalse(partyCLI.selectMonsterToSwap(monsters.get(0), 100));
+        assertTrue(acquireOutput().contains("Invalid input!"));
+
+        // Move with invalid input, and then properly swap with 1
+        provideInput("1");
+        assertTrue(partyCLI.selectMonsterToSwap(monsters.get(0), 100));
+        assertTrue(acquireOutput().contains("Invalid input!"));
+        assertEquals(monsters.get(0), trainer.getParty().get(0));
+        assertNotEquals(monsters.get(1), trainer.getParty().get(0));
+        assertEquals("1", trainer.getParty().get(0).getName());
+        assertEquals("2", trainer.getParty().get(1).getName());
+    }
+
+    @Test
+    void displayPartyStats() {
+        partyCLI.displayPartyStats(false);
+        final var res0 = acquireOutput();
+        assertFalse(Stream.of(1, 2, 3, 4).map(Object::toString).anyMatch(s -> res0.contains(s + " - ")));
+
+        final var trainer = gameManager.getTrainer();
+        final var monsters = List.of(new Monster.Quacker("1", 1), new Monster.Eel("2", 1));
+        monsters.forEach(trainer::add);
+        partyCLI.displayPartyStats(false);
+        final var res1 = acquireOutput();
+        assertTrue(monsters.stream()
+            .map(mon ->
+                String.format("\n%s - %s (Level %d, %d/%d HP)\n", mon.getName(), mon.getName(), mon.getLevel(), mon.getCurrentHp(), mon.maxHp())
+                    + String.format("Monster Type: %s\n", mon.monsterType())
+                    + String.format("Sell Price: %d Gold\n", mon.sellPrice())
+                    + String.format("Attack Damage: %d\n", mon.scaledDamage())
+                    + String.format("Speed: %d\n", mon.speed())
+                    + String.format("Overnight Heal Rate: %d\n", mon.healRate())
+                    + String.format("Ideal Environment: %s\n", mon.idealEnvironment())
+            )
+            .allMatch(res1::contains)
+        );
+    }
+
+    @Test
+    void displayMoveMonsters() {
+        partyCLI.displayMoveMonsters(new Monster.Tree("A", 1));
+        final var res0 = acquireOutput();
+        assertTrue(res0.contains("Which monster would you like to swap A with?"));
+        assertFalse(Stream.of(1, 2, 3, 4).map(Object::toString).anyMatch(s -> res0.contains(s + " - ")));
+
+        final var trainer = gameManager.getTrainer();
+        List.of(new Monster.Quacker("1", 1), new Monster.Eel("2", 1)).forEach(trainer::add);
+        partyCLI.displayMoveMonsters(new Monster.Tree("A", 1));
+        final var res1 = acquireOutput();
+        assertTrue(Stream.of(1, 2).map(Object::toString).allMatch(s -> res1.contains(s + " - " + s)));
+    }
+}

--- a/app/src/test/java/seng/monsters/ui/cli/PartyCLITest.java
+++ b/app/src/test/java/seng/monsters/ui/cli/PartyCLITest.java
@@ -33,6 +33,16 @@ class PartyCLITest extends CLITestBase {
         baseTeardown();
     }
 
+    /**
+     * PartyCLi's <code>partyStatsInterface</code> should:
+     * <ul>
+     * <li>Perform nothing and exit if given <code>"0"</code> user input</li>
+     * <li>Swap monsters if given 2 valid indices user inputs</li>
+     * <li>Not swap monsters if given only 1 valid index user input</li>
+     * <li>Output <code>"Invalid input!</code> if given 1 invalid index</li>
+     * <li>Be able to loop back and perform proper even after given 1 invalid index</li>
+     * </ul>
+     */
     @Test
     void partyStatsInterface() {
         final var trainer = gameManager.getTrainer();
@@ -74,6 +84,15 @@ class PartyCLITest extends CLITestBase {
         assertEquals("2", trainer.getParty().get(1).getName());
     }
 
+    /**
+     * PartyCLi's <code>moveMonsterInterface</code> should:
+     * <ul>
+     * <li>Perform nothing and exit if given <code>"0"</code> user input</li>
+     * <li>Swap monsters if given an existing monster and a valid index user inputs</li>
+     * <li>Output <code>"Invalid input!</code> if given 1 invalid index or non-existing monster</li>
+     * <li>Be able to loop back and perform proper even after given 1 invalid index</li>
+     * </ul>
+     */
     @Test
     void moveMonsterInterface() {
         final var trainer = gameManager.getTrainer();
@@ -107,6 +126,16 @@ class PartyCLITest extends CLITestBase {
         assertEquals("2", trainer.getParty().get(1).getName());
     }
 
+    /**
+     * PartyCLi's <code>selectMonsterToMove</code> should:
+     * <ul>
+     * <li>Perform nothing and exit if given <code>"0"</code> user input</li>
+     * <li>Swap monsters if given 2 valid indices user inputs</li>
+     * <li>Not swap monsters if given only 1 valid index user input</li>
+     * <li>Output <code>"Invalid input!</code> if given 1 invalid index</li>
+     * <li>Be able to loop back and perform proper even after given 1 invalid index</li>
+     * </ul>
+     */
     @Test
     void selectMonsterToMove() {
         final var trainer = gameManager.getTrainer();
@@ -146,6 +175,15 @@ class PartyCLITest extends CLITestBase {
         assertEquals("2", trainer.getParty().get(1).getName());
     }
 
+    /**
+     * PartyCLi's <code>selectMonsterToSwap</code> should:
+     * <ul>
+     * <li>Perform nothing and exit if given <code>"0"</code> user input</li>
+     * <li>Swap monsters if given an existing monster and a valid index user inputs</li>
+     * <li>Output <code>"Invalid input!</code> if given 1 invalid index or non-existing monster</li>
+     * <li>Be able to loop back and perform proper even after given 1 invalid index</li>
+     * </ul>
+     */
     @Test
     void selectMonsterToSwap() {
         final var trainer = gameManager.getTrainer();
@@ -176,6 +214,12 @@ class PartyCLITest extends CLITestBase {
         assertEquals("2", trainer.getParty().get(1).getName());
     }
 
+    /**
+     * PartyCLi's <code>displayPartyStats</code> should:
+     * <ul>
+     * <li>Display all monsters in the player's party full statistics</li>
+     * </ul>
+     */
     @Test
     void displayPartyStats() {
         partyCLI.displayPartyStats(false);
@@ -201,6 +245,12 @@ class PartyCLITest extends CLITestBase {
         );
     }
 
+    /**
+     * PartyCLi's <code>displayPartyStats</code> should:
+     * <ul>
+     * <li>Display all monsters in the player's party, only their name</li>
+     * </ul>
+     */
     @Test
     void displayMoveMonsters() {
         partyCLI.displayMoveMonsters(new Monster.Tree("A", 1));

--- a/app/src/test/java/seng/monsters/ui/cli/SetupCLITest.java
+++ b/app/src/test/java/seng/monsters/ui/cli/SetupCLITest.java
@@ -1,0 +1,208 @@
+package seng.monsters.ui.cli;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SetupCLITest extends CLITestBase {
+    private SetupCLI setupCLI;
+
+    @BeforeEach
+    void setUp() {
+        setupCLI = new SetupCLI();
+        baseSetup();
+    }
+
+
+    @Override
+    public TestableCLI cli() {
+        return setupCLI;
+    }
+
+    @AfterEach
+    void tearDown() {
+        baseTeardown();
+    }
+
+    /**
+     * SetupCLI's <code>chooseNameInterface</code>:
+     * <ul>
+     * <li>Return a valid string if given a valid username (3-15 characters, just letters)</li>
+     * <li>Return only the valid string if given multiple inputs (last 1 valid and the remaining are invalid)</li>
+     * </ul>
+     */
+    @Test
+    void chooseNameInterface() {
+        // Valid input
+        provideInput("ThisIsValid");
+        final var name1 = setupCLI.chooseNameInterface();
+        assertEquals("ThisIsValid", name1);
+
+        // Invalid (just symbols, mixed w/ numbers, mixed all, 2 characters, over 15 characters, then valid
+        provideMultipleInput(List.of("#*(#))*", "Invalid1", "Invalid#$2", "aa", "AAAAAAAAAAAAAAAAAAAAAAAAAAAAA", "ThisIsValid"));
+        final var name2 = setupCLI.chooseNameInterface();
+        assertEquals("ThisIsValid", name2);
+    }
+
+    /**
+     * SetupCLI's <code>chooseMaxDaysInterface</code>:
+     * <ul>
+     * <li>Return a valid max days if given a valid integer (5-15 inclusive)</li>
+     * <li>Return only the valid max days if given multiple inputs (last 1 valid and the remaining are invalid)</li>
+     * </ul>
+     */
+    @Test
+    void chooseMaxDaysInterface() {
+        // Valid input
+        provideInput("5");
+        final var maxDays1 = setupCLI.chooseMaxDaysInterface();
+        assertTrue(acquireOutput().contains("5 days chosen."));
+        assertEquals(5, maxDays1);
+
+        // Invalid then valid
+        provideMultipleInput(List.of("1000", "5"));
+        final var maxDays2 = setupCLI.chooseMaxDaysInterface();
+        assertEquals(5, maxDays2);
+        assertTrue(acquireOutput().contains("Invalid input! (Must be a number between 5 and 15 inclusive)"));
+    }
+
+    /**
+     * SetupCLI's <code>selectDifficultyInterface</code>:
+     * <ul>
+     * <li>Return a valid difficulty scale if given a valid integer (1-3 inclusive)</li>
+     * <li>Return only the valid difficulty if given multiple inputs (last 1 valid and the remaining are invalid)</li>
+     * </ul>
+     */
+    @Test
+    void selectDifficultyInterface() {
+        // Valid difficulty
+        provideInput("1");
+        final var difficulty1 = setupCLI.selectDifficultyInterface();
+        assertEquals(1, difficulty1);
+
+
+        // Invalid once and then valid
+        provideMultipleInput(List.of("100", "3"));
+        final var difficulty2 = setupCLI.selectDifficultyInterface();
+        assertEquals(3, difficulty2);
+    }
+
+    /**
+     * SetupCLI's <code>selectStartingMonsterInterface</code>:
+     * <ul>
+     * <li>Return a monster picked from the starter selection if given a valid integer (1-3 inclusive)</li>
+     * <li>Rename the monster if given a name as the second input,</li>
+     * <li>Skip and loop again if given invalid index</li>
+     * </ul>
+     */
+    @Test
+    void selectStartingMonsterInterface() {
+        // Valid monster index
+        provideMultipleInput(List.of("1", "Honkers"));
+        final var startingMonster1 = setupCLI.selectStartingMonsterInterface();
+        assertEquals("Quacker", startingMonster1.monsterType());
+        assertEquals(1, startingMonster1.getLevel());
+        assertEquals("Honkers", startingMonster1.getName());
+
+
+        // Invalid once, and then valid index
+        provideMultipleInput(List.of("100", "2", "Crab"));
+        final var startingMonster2 = setupCLI.selectStartingMonsterInterface();
+        assertTrue(acquireOutput().contains("Invalid input!"));
+        assertEquals("Raver", startingMonster2.monsterType());
+        assertEquals(1, startingMonster2.getLevel());
+        assertEquals("Crab", startingMonster2.getName());
+    }
+
+    /**
+     * SetupCLI's <code>chooseName</code>:
+     * <ul>
+     * <li>Return a valid string if given a valid username (3-15 characters, just letters)</li>
+     * <li>Return only the valid string if given multiple inputs (last 1 valid and the remaining are invalid)</li>
+     * </ul>
+     */
+    @Test
+    void chooseName() {
+        // Valid input
+        final var name1 = setupCLI.chooseName("ThisIsValid");
+        assertEquals("ThisIsValid", name1);
+
+        // Invalid (just symbols, mixed w/ numbers, mixed all, 2 characters, over 15 characters, then valid
+        provideMultipleInput(List.of("Invalid1", "Invalid#$2", "aa", "AAAAAAAAAAAAAAAAAAAAAAAAAAAAA", "ThisIsValid"));
+        final var name2 = setupCLI.chooseName("#*(#))*");
+        assertEquals("ThisIsValid", name2);
+    }
+
+    /**
+     * SetupCLI's <code>chooseMaxDays</code>:
+     * <ul>
+     * <li>Return a valid max days if given a valid integer (5-15 inclusive)</li>
+     * <li>Return only the valid max days if given multiple inputs (last 1 valid and the remaining are invalid)</li>
+     * </ul>
+     */
+    @Test
+    void chooseMaxDays() {
+        // Valid input
+        final var maxDays1 = setupCLI.chooseMaxDays(5);
+        assertTrue(acquireOutput().contains("5 days chosen."));
+        assertEquals(5, maxDays1);
+
+        // Invalid then valid
+        provideInput("5");
+        final var maxDays2 = setupCLI.chooseMaxDays(1000);
+        assertEquals(5, maxDays2);
+        assertTrue(acquireOutput().contains("Invalid input! (Must be a number between 5 and 15 inclusive)"));
+    }
+
+    /**
+     * SetupCLI's <code>selectDifficulty</code>:
+     * <ul>
+     * <li>Return a valid difficulty scale if given a valid integer (1-3 inclusive)</li>
+     * <li>Return only the valid difficulty if given multiple inputs (last 1 valid and the remaining are invalid)</li>
+     * </ul>
+     */
+    @Test
+    void selectDifficulty() {
+        // Valid difficulty
+        final var difficulty1 = setupCLI.selectDifficulty(1);
+        assertEquals(1, difficulty1);
+
+
+        // Invalid once and then valid
+        provideInput("3");
+        final var difficulty2 = setupCLI.selectDifficulty(100);
+        assertEquals(3, difficulty2);
+    }
+
+    /**
+     * SetupCLI's <code>selectStartingMonster</code>:
+     * <ul>
+     * <li>Return a monster picked from the starter selection if given a valid integer (1-3 inclusive)</li>
+     * <li>Rename the monster if given a name as the second input,</li>
+     * <li>Skip and loop again if given invalid index</li>
+     * </ul>
+     */
+    @Test
+    void selectStartingMonster() {
+        // Valid monster index
+        provideInput("Honkers");
+        final var startingMonster1 = setupCLI.selectStartingMonster(1);
+        assertEquals("Quacker", startingMonster1.monsterType());
+        assertEquals(1, startingMonster1.getLevel());
+        assertEquals("Honkers", startingMonster1.getName());
+
+
+        // Invalid once, and then valid index
+        provideMultipleInput(List.of("2", "Crab"));
+        final var startingMonster2 = setupCLI.selectStartingMonster(100);
+        assertTrue(acquireOutput().contains("Invalid input!"));
+        assertEquals("Raver", startingMonster2.monsterType());
+        assertEquals(1, startingMonster2.getLevel());
+        assertEquals("Crab", startingMonster2.getName());
+    }
+}


### PR DESCRIPTION
### Description
Added unit test for all `CLI` classes, that can also utilize a custom `System.in` to allow `Scanner` to take hardcoded input. This is achieved with making all `CLI` classes extends `TestableCLI` that provide the `Scanner` that use a custom delimiter  and can be refreshed to use  the current `System.in` for cases where the `System.in` has been updated with the new hardcoded values while also not breaking the code when used normally. On top of that, making all `CLITest` extends the `CLITestBase` that utilize the `TestableCLI`.

### Changes
- Added `TestableCLI`
- Updated `PartyCLI`, `InventoryCLI`, `SetupCLI`, `BattleCLI`, and `MainMenuCLI` to extends `TestableCLI`
- Added `CLITestCase` in the test folder
- Added `PartyCLI`
- Added `InventoryCLI`
- Fixed fetching item count issues with `Inventory`