### PR TITLE
Fixes and Improvement patch

### DIFF
--- a/app/src/main/java/seng/monsters/model/Monster.java
+++ b/app/src/main/java/seng/monsters/model/Monster.java
@@ -54,12 +54,12 @@ public abstract class Monster implements Purchasable {
 
         @Override
         public Environment idealEnvironment() {
-            return Environment.BEACH;
+            return Environment.HILL;
         }
 
         @Override
         public boolean shouldLevelUp() {
-            return Math.random() <= 0.4;
+            return Math.random() <= 0.6;
         }
 
         @Override
@@ -169,7 +169,12 @@ public abstract class Monster implements Purchasable {
 
         @Override
         public boolean shouldLevelUp() {
-            return Math.random() <= 0.3;
+            return !isFainted() || Math.random() <= 0.8;
+        }
+
+        @Override
+        public int sellPrice() {
+            return buyPrice();
         }
 
         @Override
@@ -225,7 +230,7 @@ public abstract class Monster implements Purchasable {
 
         @Override
         public Environment idealEnvironment() {
-            return Environment.DESERT;
+            return Environment.URBAN;
         }
 
         @Override
@@ -614,6 +619,18 @@ public abstract class Monster implements Purchasable {
         if (other instanceof Monster mon)
             return this.getId().equals(mon.getId());
         return false;
+    }
+
+    /**
+     * Gives a combination of name and id to create a unique identifier that still recognizable by name
+     *
+     * @return A string of name and id combined
+     */
+    public String uniqueName() {
+        return String.format("%s (%s)",
+            getName(),
+            getId().toString().substring(0, 8)
+        );
     }
 
     /**

--- a/app/src/main/java/seng/monsters/ui/gui/BattleScreen.java
+++ b/app/src/main/java/seng/monsters/ui/gui/BattleScreen.java
@@ -8,6 +8,7 @@ package seng.monsters.ui.gui;
 
 import seng.monsters.model.BattleManager;
 import seng.monsters.model.GameManager;
+import seng.monsters.model.Monster;
 
 import javax.swing.*;
 import java.awt.*;
@@ -163,6 +164,7 @@ public final class BattleScreen extends Screen implements BattleManager.UI {
         playerMonsterNameLabel = new JLabel(String.format(
             "%s (lvl: %d)", battleManager.getBattlingPlayerMonster().getName(), battleManager.getBattlingPlayerMonster().getLevel()
         ));
+        playerMonsterNameLabel.setForeground(boostedColor(battleManager.getBattlingPlayerMonster()));
         playerMonsterNameLabel.setBackground(new Color(192, 192, 192));
         playerMonsterNameLabel.setHorizontalAlignment(SwingConstants.CENTER);
         playerMonsterNameLabel.setBounds(62, 256, 200, 33);
@@ -181,6 +183,7 @@ public final class BattleScreen extends Screen implements BattleManager.UI {
         enemyMonsterNameLabel = new JLabel(String.format(
             "%s (lvl: %d)", battleManager.getBattlingEnemyMonster().getName(), battleManager.getBattlingEnemyMonster().getLevel()
         ));
+        enemyMonsterNameLabel.setForeground(boostedColor(battleManager.getBattlingEnemyMonster()));
         enemyMonsterNameLabel.setOpaque(true);
         enemyMonsterNameLabel.setHorizontalAlignment(SwingConstants.CENTER);
         enemyMonsterNameLabel.setBackground(Color.LIGHT_GRAY);
@@ -293,12 +296,14 @@ public final class BattleScreen extends Screen implements BattleManager.UI {
         playerMonsterNameLabel.setText(String.format(
             "%s (lvl: %d)", battleManager.getBattlingPlayerMonster().getName(), battleManager.getBattlingPlayerMonster().getLevel()
         ));
+        playerMonsterNameLabel.setForeground(boostedColor(battleManager.getBattlingPlayerMonster()));
         playerMonsterHpLabel.setText(String.format(
             "HP: %d/%d", battleManager.getBattlingPlayerMonster().getCurrentHp(), battleManager.getBattlingPlayerMonster().maxHp()
         ));
         enemyMonsterNameLabel.setText(String.format(
             "%s (lvl: %d)", battleManager.getBattlingEnemyMonster().getName(), battleManager.getBattlingEnemyMonster().getLevel()
         ));
+        enemyMonsterNameLabel.setForeground(boostedColor(battleManager.getBattlingEnemyMonster()));
         enemyMonsterHpLabel.setText(String.format(
             "HP: %d/%d", battleManager.getBattlingEnemyMonster().getCurrentHp(), battleManager.getBattlingEnemyMonster().maxHp()
         ));
@@ -428,5 +433,11 @@ public final class BattleScreen extends Screen implements BattleManager.UI {
             gameManager.setGold(gameManager.getGold() + battleManager.goldReward() * gameManager.getDifficulty());
             gameManager.setScore(gameManager.getScore() + battleManager.scoreReward() * gameManager.getDifficulty());
         }
+    }
+
+    private Color boostedColor(Monster monster) {
+        if (monster.idealEnvironment() == gameManager.getEnvironment())
+            return new Color(160, 28, 193);
+        return Color.BLACK;
     }
 }

--- a/app/src/main/java/seng/monsters/ui/gui/InventoryScreen.java
+++ b/app/src/main/java/seng/monsters/ui/gui/InventoryScreen.java
@@ -168,11 +168,6 @@ public class InventoryScreen extends Screen {
         return (ignoredEvent, monster) -> {
             try {
                 gameManager.useItemFromInventory(item, monster);
-
-                final var newCount = inventory.getItemNumber(item);
-                countLabel.setText(String.format("%dx", newCount));
-                sellButton.setEnabled(newCount > 0);
-                useButton.setEnabled(newCount > 0);
                 errorLabel.setVisible(false);
             } catch (Inventory.ItemNotExistException err) {
                 errorLabel.setText("There is no such item in your inventory");
@@ -183,6 +178,11 @@ public class InventoryScreen extends Screen {
             } catch (Item.NoEffectException err) {
                 errorLabel.setText("The item produces no effect, " + err.getMessage());
                 errorLabel.setVisible(true);
+            } finally {
+                final var newCount = inventory.getItemNumber(item);
+                countLabel.setText(String.format("%dx", newCount));
+                sellButton.setEnabled(newCount > 0);
+                useButton.setEnabled(newCount > 0);
             }
         };
     }

--- a/app/src/main/java/seng/monsters/ui/gui/MainMenuScreen.java
+++ b/app/src/main/java/seng/monsters/ui/gui/MainMenuScreen.java
@@ -34,6 +34,7 @@ public class MainMenuScreen extends Screen {
         JButton partyButton = new JButton("Party");
         partyButton.setFont(new Font("Lucida Grande", Font.PLAIN, 15));
         partyButton.setBounds(38, 45, 150, 40);
+        partyButton.setEnabled(!gameManager.getTrainer().getParty().isEmpty());
         frame.getContentPane().add(partyButton);
 
         JButton inventoryButton = new JButton("Inventory");

--- a/app/src/main/java/seng/monsters/ui/gui/MonsterShopScreen.java
+++ b/app/src/main/java/seng/monsters/ui/gui/MonsterShopScreen.java
@@ -82,7 +82,7 @@ public class MonsterShopScreen extends Screen {
 
         JComboBox<String> monsterStockComboBox = new JComboBox<>();
         monsterStockComboBox.setModel(
-            new LabelComboboxModel<>(gameManager.getShop().getMonsterStock(), this::uniqueMonsterIdentifier)
+            new LabelComboboxModel<>(gameManager.getShop().getMonsterStock(), Monster::uniqueName)
         );
         monsterStockComboBox.setSelectedIndex(0);
         monsterStockComboBox.setBounds(0, 70, 236, 30);
@@ -124,7 +124,7 @@ public class MonsterShopScreen extends Screen {
     private ActionListener comboBoxSelectionAction(JComboBox<String> comboBox) {
         return ignoredEvent -> {
             final var index = comboBox.getSelectedIndex();
-            if (index < 0)
+            if (index < 0 || index >= gameManager.getShop().getMonsterStock().size())
                 return;
             chosenMonster.set(gameManager.getShop().getMonsterStock().get(index));
         };
@@ -160,15 +160,15 @@ public class MonsterShopScreen extends Screen {
                 final var stock = gameManager.getShop().getMonsterStock();
                 if (stock.isEmpty()) {
                     gui.navigateBackToMainMenu();
-                    return;
+                } else {
+                    partyComboBox.setModel(
+                        new LabelComboboxModel<>(stock, Monster::uniqueName)
+                    );
+                    partyComboBox.setSelectedIndex(0);
+                    chosenMonster.set(stock.get(0));
+                    buyButton.setEnabled(true);
+                    goldLabel.setText(String.format("Your own %d gold", gameManager.getGold()));
                 }
-                partyComboBox.setModel(
-                    new LabelComboboxModel<>(stock, this::uniqueMonsterIdentifier)
-                );
-                partyComboBox.setSelectedIndex(0);
-                chosenMonster.set(stock.get(0));
-                buyButton.setEnabled(true);
-                goldLabel.setText(String.format("Your own %d gold", gameManager.getGold()));
             }
         };
     }
@@ -178,14 +178,5 @@ public class MonsterShopScreen extends Screen {
      */
     private ActionListener backToMainMenuAction() {
         return ignoredEvent -> gui.navigateBackToMainMenu();
-    }
-
-    /**
-     * A special string to identify all monster uniquely regardless of name and type
-     * @param mon The monster in question
-     * @return A string of name (id)
-     */
-    private String uniqueMonsterIdentifier(Monster mon) {
-        return String.format("%s (%s)", mon.getName(), mon.getId().toString().substring(0, 8));
     }
 }

--- a/app/src/main/java/seng/monsters/ui/gui/TitleScreen.java
+++ b/app/src/main/java/seng/monsters/ui/gui/TitleScreen.java
@@ -80,7 +80,7 @@ public class TitleScreen extends Screen {
                 gui.navigateTo(new SettingsScreen(gui, gameManager));
             } catch (IllegalArgumentException ignored) {
                 errorLabel.setVisible(true);
-                errorLabel.setText("Invalid name! (Must be between 3 and 15 letters inclusive, no symbols or numbers)");
+                errorLabel.setText("<html>Invalid name! (Must be between 3 and 15 letters inclusive, no symbols or numbers)</html>");
             }
         };
     }

--- a/app/src/main/java/seng/monsters/ui/gui/components/JoiningPopUp.java
+++ b/app/src/main/java/seng/monsters/ui/gui/components/JoiningPopUp.java
@@ -77,7 +77,7 @@ public class JoiningPopUp extends PopUp {
         JLabel errorLabel = new JLabel("Name your monster:");
         errorLabel.setForeground(new Color(255, 0, 0));
         errorLabel.setHorizontalAlignment(SwingConstants.CENTER);
-        errorLabel.setBounds(125, 246, 229, 16);
+        errorLabel.setBounds(125, 246, 229, 32);
         errorLabel.setVisible(false);
         frame.getContentPane().add(errorLabel);
 
@@ -110,7 +110,7 @@ public class JoiningPopUp extends PopUp {
                 onEnd.accept(ignoredEvent);
                 frame.dispose();
             } catch (IllegalArgumentException ignored) {
-                errorLabel.setText("Must be 3 to 15 characters and not contain only contains letters!");
+                errorLabel.setText("<html>Must be 3 to 15 characters and not contain only contains letters!</html>");
                 errorLabel.setVisible(true);
             }
         };

--- a/app/src/main/java/seng/monsters/ui/gui/components/PartySlotPanel.java
+++ b/app/src/main/java/seng/monsters/ui/gui/components/PartySlotPanel.java
@@ -163,9 +163,9 @@ public final class PartySlotPanel {
 
         hpLabel = new JLabel();
         hpLabel.setText(String.format("%d/%d", monster.getCurrentHp(), monster.maxHp()));
-        hpLabel.setHorizontalAlignment(SwingConstants.CENTER);
+        hpLabel.setHorizontalAlignment(SwingConstants.LEADING);
         hpLabel.setFont(new Font("Lucida Grande", Font.PLAIN, 11));
-        hpLabel.setBounds(55, 34, 51, 11);
+        hpLabel.setBounds(55, 34, 220, 11);
         panel.add(hpLabel);
 
         currHpPanel = new JPanel();


### PR DESCRIPTION
- Fixed issue with visibility of text
- Fixed issue with longer text not wrapped
- Fixed issue with inventory item's use button being disabled if an exception was thrown
- Changed the `SelectPartyPopUp` to use `PartyPanel` instead of a combo box, since it provides a cleaner UI and party is limited to 4 monsters
- Buffed `Tree` level up chance
- Buffed `Quacker` level up chance
- Buffed `Tree` selling price
- Rebalanced ideal environment values for all monsters
- Added change in name color on `BattleScreen` if a monster is in its ideal environment 